### PR TITLE
Some typos removed

### DIFF
--- a/07.templates.md
+++ b/07.templates.md
@@ -434,7 +434,7 @@ lessThan7(a); //  Инстанцирование
 
 При определении перегрузок функции ошибочные инстанциации шаблонов не вызывают ошибку компиляции, а отбрасываются из списка кандидатов на наиболее подходящую перегрузку.
 
-Неудачная инстанцирование шаблона - это не ошибка.
+Неудачное инстанцирование шаблона - это не ошибка.
 
 Например, позволяет на этапе компиляции выбрать нужную функцию:
 
@@ -505,7 +505,7 @@ void clear(T& t, std::enable_if_t<std::is_pod<T>::value>* = nullptr)
 
 // Для не-POD типов
 template<typename T>
-void clear(T& t, std::enable_if<!std::is_pod<T>::value>* = nullptr)
+void clear(T& t, std::enable_if_t<!std::is_pod<T>::value>* = nullptr)
 {
     t = T{};
 }
@@ -703,7 +703,8 @@ public:
     }
 };
 
-using JsonConnector = Connector<Json>;
+template<class T>
+using JsonConnector = Connector<T, Json>;
 ```
 
 ### Отличия между свойствами и стратегиями


### PR DESCRIPTION
1) Spelling typo in plain text
2) enable_if_t instead of enable_if in C++14 section
3) JsonConnector in strategies now works fine